### PR TITLE
Introduced `NoConfigResolverParametersInConstructorRule` PHPStan custom rule

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -1,0 +1,71 @@
+name: Backend build
+
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+'
+    pull_request: ~
+
+jobs:
+    cs-fix:
+        name: Run code style check
+        runs-on: "ubuntu-22.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.1'
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: 'pdo_sqlite, gd'
+                    tools: cs2pr
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    dependency-versions: "highest"
+
+            -   name: Run code style check
+                run: composer run-script check-cs -- --format=checkstyle | cs2pr
+
+    tests:
+        name: Tests
+        runs-on: "ubuntu-22.04"
+        timeout-minutes: 10
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php:
+                    - '7.4'
+                    - '8.3'
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: pdo_sqlite, gd
+                    tools: cs2pr
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    dependency-versions: "highest"
+                    composer-options: "--prefer-dist --no-progress --no-suggest"
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Run PHPStan analysis
+                run: composer run-script phpstan
+
+            -   name: Run test suite
+                run: composer run-script --timeout=600 test

--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.1'
+                    - '8.3'
         steps:
             -   uses: actions/checkout@v4
 

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+return \Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory::build()->setFinder(
+    PhpCsFixer\Finder::create()
+        ->in(__DIR__ . '/rules')
+        ->in(__DIR__ . '/tests')
+        ->files()->name('*.php')
+);

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,54 @@
 {
-  "name": "ibexa/phpstan",
-  "license": "proprietary",
-  "type": "ibexa-bundle",
-  "keywords": [
-    "ibexa-dxp"
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0"
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "extra": {
-    "phpstan": {
-      "includes": [
-        "extension.neon"
-      ]
+    "name": "ibexa/phpstan",
+    "license": "proprietary",
+    "type": "ibexa-bundle",
+    "keywords": [
+        "ibexa-dxp"
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ibexa/core": "4.6.x-dev",
+        "ibexa/doctrine-schema": "4.6.x-dev"
+    },
+    "require-dev": {
+        "ibexa/code-style": "~2.0.0",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-strict-rules": "^1.6",
+        "phpstan/phpstan-symfony": "^1.3",
+        "phpunit/phpunit": "^9"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ibexa\\PHPStan\\Rules\\": "rules/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ibexa\\Tests\\PHPStan\\Rules\\": "tests/rules/"
+        }
+    },
+    "scripts": {
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml.dist",
+        "phpstan": "phpstan analyse -c phpstan.neon"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Automatically fixes code style in all files",
+        "check-cs": "Run code style checker for all files",
+        "test": "Run automatic tests",
+        "phpstan": "Run static code analysis"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": false
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
+        }
     }
-  }
 }

--- a/extension.neon
+++ b/extension.neon
@@ -5,3 +5,5 @@ parameters:
 		- stubs/Money/Money.stub
 		- stubs/Money/MoneyFormatter.stub
 		- stubs/Money/MoneyParser.stub
+rules:
+    - Ibexa\PHPStan\Rules\NoConfigResolverParametersInConstructorRule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 8
+    paths:
+        - rules
+        - tests
+    checkMissingCallableSignature: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        bootstrap="vendor/autoload.php"
+        failOnWarning="true"
+        colors="true">
+    <testsuites>
+        <testsuite name="rules">
+            <directory>tests/rules</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/rules/NoConfigResolverParametersInConstructorRule.php
+++ b/rules/NoConfigResolverParametersInConstructorRule.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PHPStan\Rules;
+
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ */
+final class NoConfigResolverParametersInConstructorRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    /**
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $function = $scope->getFunction();
+        if ($function !== null && $function->getName() !== '__construct') {
+            return [];
+        }
+
+        /** @var \PhpParser\Node\Identifier $nodeName */
+        $nodeName = $node->name;
+        $methodName = $nodeName->name;
+
+        if (
+            $methodName !== 'getParameter'
+            && $methodName !== 'hasParameter'
+            && !isset($node->getArgs()[0])
+        ) {
+            return [];
+        }
+
+        $type = $scope->getType($node->var);
+        $configResolverInterfaceType = new ObjectType(ConfigResolverInterface::class);
+        if (!$configResolverInterfaceType->isSuperTypeOf($type)->yes()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder
+                ::message('Referring to ConfigResolver parameters in constructor is not allowed due to potential scope change.')
+                ->identifier('Ibexa.NoConfigResolverParametersInConstructor')
+                ->nonIgnorable()
+                ->build(),
+        ];
+    }
+}

--- a/tests/rules/Fixtures/NoConfigResolverParametersInConstructorFixture.php
+++ b/tests/rules/Fixtures/NoConfigResolverParametersInConstructorFixture.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\PHPStan\Rules\Fixtures;
+
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+
+final class NoConfigResolverParametersInConstructorFixture
+{
+    private ConfigResolverInterface $configResolver;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+
+        $configResolver->hasParameter('foo');
+        $configResolver->getParameter('foo');
+    }
+
+    public function foo(): void
+    {
+        //this is allowed outside of constructor - no error reported by PHPStan
+        $this->configResolver->hasParameter('bar');
+    }
+}

--- a/tests/rules/NoConfigResolverParametersInConstructorRuleTest.php
+++ b/tests/rules/NoConfigResolverParametersInConstructorRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\PHPStan\Rules;
+
+use Ibexa\PHPStan\Rules\NoConfigResolverParametersInConstructorRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\Ibexa\PHPStan\Rules\NoConfigResolverParametersInConstructorRule>
+ */
+final class NoConfigResolverParametersInConstructorRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+       return new NoConfigResolverParametersInConstructorRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixtures/NoConfigResolverParametersInConstructorFixture.php',
+            ],
+            [
+                [
+                    'Referring to ConfigResolver parameters in constructor is not allowed due to potential scope change.',
+                    21,
+                ],
+                [
+                    'Referring to ConfigResolver parameters in constructor is not allowed due to potential scope change.',
+                    22,
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | - |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Introduced our first custom rule to PHPStan. It guards referring to config resolver parameters in constructor (usage of methods: `hasParameter` and `getParameter`).

Note: I decided to make it `nonIgnorable` which means it cannot be put into baseline. To me it is should be enforced rather than suggested as SiteAccess scope change might corrupt the actual outcome.

`composer phpstan` will produce the following:

![Zrzut ekranu 2024-12-11 o 15 34 31](https://github.com/user-attachments/assets/c73d084c-fde2-4aad-911c-3c844d68576a)


Moreover I provided PHPUnit coverage aligned with recommendations, ref: https://phpstan.org/developing-extensions/testing#custom-rules.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
