### PR TITLE
Added rule to enforce typehints to closure and arrow functions

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -7,3 +7,4 @@ parameters:
 		- stubs/Money/MoneyParser.stub
 rules:
     - Ibexa\PHPStan\Rules\NoConfigResolverParametersInConstructorRule
+    - Ibexa\PHPStan\Rules\RequireClosureReturnTypeRule

--- a/rules/RequireClosureReturnTypeRule.php
+++ b/rules/RequireClosureReturnTypeRule.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Node\Expr>
+ */
+final class RequireClosureReturnTypeRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Node\Expr\Closure && !$node instanceof Node\Expr\ArrowFunction) {
+            return [];
+        }
+
+        if ($node->returnType === null) {
+            $nodeType = $node instanceof Node\Expr\Closure ? 'Closure' : 'Arrow function';
+
+            return [
+                RuleErrorBuilder::message(
+                    sprintf('%s is missing a return type declaration', $nodeType)
+                )->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/rules/Fixtures/RequireClosureReturnTypeFixture.php
+++ b/tests/rules/Fixtures/RequireClosureReturnTypeFixture.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\PHPStan\Rules\Fixtures;
+
+final class RequireClosureReturnTypeFixture
+{
+    public function closureWithoutReturnType(): void
+    {
+        // Error: Closure without return type
+        $closure = static function ($x) {
+            return $x * 2;
+        };
+    }
+
+    public function closureWithReturnType(): void
+    {
+        // OK: Closure has return type
+        $closure = static function (int $x): int {
+            return $x * 2;
+        };
+    }
+
+    public function arrowFunctionWithoutReturnType(): void
+    {
+        // Error: Arrow function without return type
+        $arrow = static fn ($x) => $x * 2;
+    }
+
+    public function arrowFunctionWithReturnType(): void
+    {
+        // OK: Arrow function has return type
+        $arrow = static fn (int $x): int => $x * 2;
+    }
+
+    public function closureWithVoidReturnType(): void
+    {
+        // OK: Closure has void return type
+        $closure = static function (): void {
+            echo 'Hello';
+        };
+    }
+
+    public function arrowFunctionWithMixedReturnType(): void
+    {
+        // OK: Arrow function has mixed return type
+        $arrow = static fn ($x): mixed => $x;
+    }
+
+    public function nestedClosuresWithoutReturnType(): void
+    {
+        // Error: Outer closure without return type
+        $outer = static function () {
+            // Error: Inner closure without return type
+            return static function ($x) {
+                return $x * 2;
+            };
+        };
+    }
+
+    public function arrayMapWithoutReturnType(): void
+    {
+        // Error: Closure without return type
+        $result = array_map(static function ($x) {
+            return $x * 2;
+        }, [1, 2, 3]);
+    }
+}

--- a/tests/rules/RequireClosureReturnTypeRuleTest.php
+++ b/tests/rules/RequireClosureReturnTypeRuleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\PHPStan\Rules;
+
+use Ibexa\PHPStan\Rules\RequireClosureReturnTypeRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\Ibexa\PHPStan\Rules\RequireClosureReturnTypeRule>
+ */
+final class RequireClosureReturnTypeRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+       return new RequireClosureReturnTypeRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixtures/RequireClosureReturnTypeFixture.php',
+            ],
+            [
+                [
+                    'Closure is missing a return type declaration',
+                    16,
+                ],
+                [
+                    'Arrow function is missing a return type declaration',
+                    32,
+                ],
+                [
+                    'Closure is missing a return type declaration',
+                    58,
+                ],
+                [
+                    'Closure is missing a return type declaration',
+                    60,
+                ],
+                [
+                    'Closure is missing a return type declaration',
+                    69,
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
for admin-ui 4.6 it reports
```
 [ERROR] Found 175 errors                                                                                               
```
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
