### PR TITLE
Fixed PHPStan rule error identifiers

### DIFF
--- a/rules/RequireClosureReturnTypeRule.php
+++ b/rules/RequireClosureReturnTypeRule.php
@@ -23,6 +23,9 @@ final class RequireClosureReturnTypeRule implements Rule
         return Node\Expr::class;
     }
 
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
     public function processNode(Node $node, Scope $scope): array
     {
         if (!$node instanceof Node\Expr\Closure && !$node instanceof Node\Expr\ArrowFunction) {
@@ -35,7 +38,7 @@ final class RequireClosureReturnTypeRule implements Rule
             return [
                 RuleErrorBuilder::message(
                     sprintf('%s is missing a return type declaration', $nodeType)
-                )->build(),
+                )->identifier('phpstan.requireClosureReturnType')->build(),
             ];
         }
 

--- a/rules/RequireClosureReturnTypeRule.php
+++ b/rules/RequireClosureReturnTypeRule.php
@@ -38,7 +38,7 @@ final class RequireClosureReturnTypeRule implements Rule
             return [
                 RuleErrorBuilder::message(
                     sprintf('%s is missing a return type declaration', $nodeType)
-                )->identifier('phpstan.requireClosureReturnType')->build(),
+                )->identifier('Ibexa.requireClosureReturnType')->build(),
             ];
         }
 


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixes:
```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   rules/RequireClosureReturnTypeRule.php                                                                                                                                    
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  35     Method Ibexa\PHPStan\Rules\RequireClosureReturnTypeRule::processNode() should return list<PHPStan\Rules\IdentifierRuleError> but returns array{PHPStan\Rules\RuleError}.  
         🪪  return.type                                                                                                                                                           
         💡  Error is missing an identifier. See: https://phpstan.org/blog/using-rule-error-builder                                                                                
         at rules/RequireClosureReturnTypeRule.php:35  
```
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
